### PR TITLE
Reduce default time-out value

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following strategies for test account provisioning are supported:
 The Action can be configured using the following inputs:
 - `ipAddress`: the IP address of the server under test. Default value: `127.0.0.1`
 - `domain`: the XMPP domain name of server under test. Default value: `example.org`
-- `timeout`: the amount of milliseconds after which an XMPP action (typically an IQ request) is considered timed out. Default value: `60000` (one minute)
+- `timeout`: the amount of milliseconds after which an XMPP action (typically an IQ request) is considered timed out. Default value: `5000` (five seconds)
 - `adminAccountUsername`: _(optional)_ The account name of a pre-existing user that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html). If not provided, in-band registration ([XEP-0077](https://xmpp.org/extensions/xep-0077.html)) will be used to provision accounts.
 - `adminAccountPassword`: _(optional)_ The password of the admin account.
 - `disabledTests`: _(optional)_ A comma-separated list of tests that are to be skipped. For example: `EntityCapsTest,SoftwareInfoIntegrationTest`

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   timeout:
     description: 'Amount of milliseconds after which an XMPP action (typically an IQ request) is considered timed out.'
     required: false
-    default: '60000'
+    default: '5000'
   adminAccountUsername:
     description: 'Account name of a pre-existing user that is allowed to create other users, per XEP-0133. If not provided, In-band registration (XEP-0077) will be used.'
     required: false


### PR DESCRIPTION
Tests are expected to finish quickly. When a timeout occurs, this is pretty much always a sign of a test failure.

As tests are executed in a test environement, in close proximity to the server under test, the default timeout can be set quite low: there is no need to account for network congestion.

Having a low default timeout value allows the failure reporting to be a lot quicker.

If need be, individual users can use the configuration option to increase the timeout value again.