### PR TITLE
Use SINT 'host' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following strategies for test account provisioning are supported:
 
 ## Inputs
 The Action can be configured using the following inputs:
-- `ipAddress`: the IP address of the server under test. Default value: `127.0.0.1`
+- `host`: IP address or DNS name of the XMPP service to run the tests on. Default value: `127.0.0.1`
 - `domain`: the XMPP domain name of server under test. Default value: `example.org`
 - `timeout`: the amount of milliseconds after which an XMPP action (typically an IQ request) is considered timed out. Default value: `5000` (five seconds)
 - `adminAccountUsername`: _(optional)_ The account name of a pre-existing user that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html). If not provided, in-band registration ([XEP-0077](https://xmpp.org/extensions/xep-0077.html)) will be used to provision accounts.

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,12 @@
 name: 'XMPP Interoperability Tests'
 description: 'Verifies functional behavior of an XMPP server by executing interoperability tests.'
 inputs:
-  ipAddress:
-    description: 'The IP address of the server under test'
+  host:
+    description: 'IP address or DNS name of the XMPP service to run the tests on.'
     required: true
     default: '127.0.0.1'
   domain:
-    description: 'XMPP domain name of server under test'
+    description: 'XMPP domain name of server under test.'
     required: true
     default: 'example.org'
   timeout:
@@ -45,9 +45,9 @@ runs:
         file: 'smack-sint-server-extensions-1.2-jar-with-dependencies.jar'
 
     - run: |
-        sudo echo "${{ inputs.ipAddress }} ${{ inputs.domain }}" | sudo tee -a /etc/hosts
         java \
           -Dsinttest.service="${{ inputs.domain }}" \
+          -Dsinttest.host="${{ inputs.host }}" \
           -Dsinttest.securityMode=disabled \
           -Dsinttest.replyTimeout=${{ inputs.timeout }} \
           -Dsinttest.adminAccountUsername="${{ inputs.adminAccountUsername }}" \


### PR DESCRIPTION
Recently, the Smack Integration Test Framework got a new configuration option, named 'host'. This allows the test to be configured with an IP address or DNS name of the XMPP service to run the tests on.

This new option negates the tricks involving setting `/etc/hosts` to make the XMPP domain name resolve to the intended host. This commit replaces that solution with the new configuration option.

Additionally, this commit renames the old 'ipAddress' configuration option to 'host', to improve consistency in nomenclature.