### PR TITLE
Add branding for Github Actions Marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     required: false
     default: './output'
 
+branding:
+  icon: 'book-open'
+  color: 'orange'
+
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
GitHub wants em, so I picked some.

![image](https://github.com/user-attachments/assets/d83b5a54-53f7-4e33-bc47-e445237afcd6)

`book-open` felt about right for standards interop. And for some reason, I associate XMPP with orange :)