### PR TITLE
Fix upstream triggered action for extra references

### DIFF
--- a/.github/workflows/upstream_release.yml
+++ b/.github/workflows/upstream_release.yml
@@ -43,7 +43,7 @@ jobs:
             VERSION=${{ github.event.client_payload.version }}
             FILE_VERSION=${VERSION:1} # Strip leading 'v'
             sed -i "s/version: 'tags/.*'/version: '${{ steps.version.outputs.version }}'/" action.yml
-            sed -i "s/file: 'smack-sint-server-extensions-.*-jar-with-dependencies.jar'/file: 'smack-sint-server-extensions-${{ steps.version.outputs.file_version }}-jar-with-dependencies.jar'/" action.yml
+            sed -i "s/smack-sint-server-extensions-.*-jar-with-dependencies.jar/smack-sint-server-extensions-${{ steps.version.outputs.file_version }}-jar-with-dependencies.jar/g" action.yml
         shell: bash
 
       - name: Create Pull Request


### PR DESCRIPTION
PRs #20 and #21 created a gap when merged together where an instance of text wouldn't be replaced by the upstream-triggered action.

This relaxes a sed replace to be less specific and hopefully catch them all.