### PR TITLE
Generated PRs should be in a Draft state

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,10 @@ env:
   CI: true
   OPENFIRE_VERSION: "4.9.0"
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 
 jobs:

--- a/.github/workflows/upstream_release.yml
+++ b/.github/workflows/upstream_release.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.5
         with:
+            draft: always-true # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
             commit-message: "Update sint-server-extensions version to ${{ steps.version.outputs.version }}"
             branch: "update-sintse-version-${{ steps.version.outputs.file_version }}"
             title: "Update sint-server-extensions version to ${{ steps.version.outputs.version }}"


### PR DESCRIPTION
Following https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs - when our new PR is created, checks don't run because of GHA intentional design.

This creates PRs as drafts, and adds Ready For Review as a  CI trigger.