### PR TITLE
Add 'enabledTests' and 'enabledSpecifications' options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The Action can be configured using the following inputs:
 - `adminAccountPassword`: _(optional)_ The password of the admin account.
 - `disabledTests`: _(optional)_ A comma-separated list of tests that are to be skipped. For example: `EntityCapsTest,SoftwareInfoIntegrationTest`
 - `disabledSpecifications`: _(optional)_ A comma-separated list of specifications (not case-sensitive) that are to be skipped. For example: `XEP-0045,XEP-0060`
+- `enabledTests`: _(optional)_ A comma-separated list of tests that are the only ones to be run. For example: `EntityCapsTest,SoftwareInfoIntegrationTest`
+- `enabledSpecifications`: _(optional)_ A comma-separated list of specifications (not case-sensitive) that are the only ones to be run. For example: `XEP-0045,XEP-0060`
 - `logDir`: _(optional)_ The directory in which the test output and logs are to be stored. This directory will be created, if it does not already exist. Default value: `./output`
 
 ## Basic Configuration


### PR DESCRIPTION
These configuration options have been available for a while, but weren't added to the readme yet.